### PR TITLE
Fix placeholder defaults

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,22 +6,23 @@ import * as vscode from 'vscode';
 import {VncSession} from './session';
 
 async function commandConnect(context: vscode.ExtensionContext): Promise<void> {
-  const hostname = await vscode.window.showInputBox({
+  const hostnameInput = await vscode.window.showInputBox({
     prompt: 'Enter VNC host name',
     placeHolder: 'localhost',
   });
-  if (!hostname) {
+  if (hostnameInput === undefined) {
     return;
   }
+  const hostname = hostnameInput || 'localhost';
 
-  const portStr = await vscode.window.showInputBox({
+  const portInput = await vscode.window.showInputBox({
     prompt: 'Enter VNC port',
     placeHolder: '5900',
   });
-  if (!portStr) {
+  if (portInput === undefined) {
     return;
   }
-  const port = Number(portStr);
+  const port = Number(portInput || '5900');
   if (isNaN(port)) {
     void vscode.window.showErrorMessage('Invalid port number');
     return;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,24 +5,29 @@
 import * as vscode from 'vscode';
 import {VncSession} from './session';
 
+const defaults = {
+  host: 'localhost',
+  port: '5900',
+};
+
 async function commandConnect(context: vscode.ExtensionContext): Promise<void> {
   const hostnameInput = await vscode.window.showInputBox({
     prompt: 'Enter VNC host name',
-    placeHolder: 'localhost',
+    placeHolder: defaults.host,
   });
   if (hostnameInput === undefined) {
     return;
   }
-  const hostname = hostnameInput || 'localhost';
+  const hostname = hostnameInput || defaults.host;
 
   const portInput = await vscode.window.showInputBox({
     prompt: 'Enter VNC port',
-    placeHolder: '5900',
+    placeHolder: defaults.port,
   });
   if (portInput === undefined) {
     return;
   }
-  const port = Number(portInput || '5900');
+  const port = Number(portInput || defaults.port);
   if (isNaN(port)) {
     void vscode.window.showErrorMessage('Invalid port number');
     return;


### PR DESCRIPTION
When confirming the `localhost` placeholder during the connection prompt, currently the second dialog for the port never appears and no action occurs. This change falls back the the placeholder, in case the user input was empty.